### PR TITLE
Adjust on sanma

### DIFF
--- a/src/routes/parlor/[parlor]/settings/ruleset/create/+page.svelte
+++ b/src/routes/parlor/[parlor]/settings/ruleset/create/+page.svelte
@@ -23,6 +23,20 @@
 		uma: [10, 5, -5, -10]
 	}
 
+	const resetUma = (threePlayer: boolean) => {
+		if (threePlayer) {
+			uma = {
+				type: 'simple',
+				uma: [10, 0, -10, 0]
+			}
+		} else {
+			uma = {
+				type: 'simple',
+				uma: [10, 5, -5, -10]
+			}
+		}
+	}
+
 	let chonbo: PrismaJson.Chonbo = {
 		type: 'score',
 		name: 'Mangan',
@@ -36,6 +50,20 @@
 	}
 
 	$: formDataObject = (formData && Object.fromEntries([...formData.entries()])) ?? {}
+
+	$: {
+		const threePlayer = formData?.get('player') === 'three'
+
+		resetUma(threePlayer)
+
+		if (threePlayer) {
+			document.getElementById('honba')?.setAttribute('value', '1000')
+			document.getElementById('tenpai')?.setAttribute('value', '2000')
+		} else {
+			document.getElementById('honba')?.setAttribute('value', '300')
+			document.getElementById('tenpai')?.setAttribute('value', '3000')
+		}
+	}
 
 	function onNoteInput() {
 		textarea.style.height = ''

--- a/src/routes/parlor/[parlor]/settings/ruleset/create/+page.svelte
+++ b/src/routes/parlor/[parlor]/settings/ruleset/create/+page.svelte
@@ -45,6 +45,9 @@
 
 	let error = ''
 
+	let honba = 300
+	let tenpai = 3000
+
 	$: {
 		scoringSheet = generateScoringSheet(scoring)
 	}
@@ -57,11 +60,11 @@
 		resetUma(threePlayer)
 
 		if (threePlayer) {
-			document.getElementById('honba')?.setAttribute('value', '1000')
-			document.getElementById('tenpai')?.setAttribute('value', '2000')
+			honba = 1000
+			tenpai = 2000
 		} else {
-			document.getElementById('honba')?.setAttribute('value', '300')
-			document.getElementById('tenpai')?.setAttribute('value', '3000')
+			honba = 300
+			tenpai = 3000
 		}
 	}
 
@@ -304,7 +307,7 @@
 						type="number"
 						id="honba"
 						name="honba"
-						value="300"
+						bind:value={honba}
 						step="100"
 						class="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500"
 					/>
@@ -316,7 +319,7 @@
 						type="number"
 						id="tenpai"
 						name="tenpai"
-						value="3000"
+						bind:value={tenpai}
 						step="1000"
 						class="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500"
 					/>

--- a/src/routes/parlor/[parlor]/settings/ruleset/create/+page.svelte
+++ b/src/routes/parlor/[parlor]/settings/ruleset/create/+page.svelte
@@ -60,7 +60,7 @@
 		resetUma(threePlayer)
 
 		if (threePlayer) {
-			honba = 1000
+			honba = 1500
 			tenpai = 2000
 		} else {
 			honba = 300

--- a/src/routes/parlor/[parlor]/settings/ruleset/create/+page.svelte
+++ b/src/routes/parlor/[parlor]/settings/ruleset/create/+page.svelte
@@ -60,7 +60,11 @@
 		resetUma(threePlayer)
 
 		if (threePlayer) {
-			honba = 1500
+			if (!scoring.tsumozon) {
+				honba = 1000
+			} else {
+				honba = 1500
+			}
 			tenpai = 2000
 		} else {
 			honba = 300


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/be746e0a-fca9-45b5-9e56-6f47b95367a9)

In ruleset editor, when you select sanma the uma, tenpai and honba doesn't change from default setting

This is problematic because uma becomes 10 / 5 / -5 which doesn't add up to 0
and tenpai fee and honba fee now has to be divisible by 200 not 300.

This PR changes these values to
uma: [10, 0, -10]
honba: 1000
tenpai fee: 2000